### PR TITLE
add German descriptions for Fastlane, improve formatting for en-US

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,11 @@
+Ein minimales Kalender-Widget, das sich immer im Monat des aktuellen Datums befindet.
+
+<b>Funktionen</b>
+
+* Enthält keine Werbung oder Zahlungen
+* Immer im Monat des aktuellen Datums
+* 3x2 (größenveränderbar)
+* Zeigt alle Ereignisse aus Ihren Kalendern mit einem Symbolsatz an (hohe Zahl wird generisch)
+* Zugriff auf die native Widget-Konfiguration oder drücken Sie auf die obere rechte Ecke des Widgets
+* Durch Drücken auf einen anderen Teil des Widgets wird die Kalenderanwendung geöffnet
+* Konfigurierbar: Starttag der Woche, Kalender (gregorianisch oder holozän), abgelehnte Ereignisse anzeigen, Fokus auf aktuelle Woche, Kalender am angeklickten Tag öffnen, Thema, Symbolsatz, Symbolsatzfarbe, Transparenz, Textgröße

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Minimales Kalender-Widget

--- a/fastlane/metadata/android/en-US/full_description.html
+++ b/fastlane/metadata/android/en-US/full_description.html
@@ -1,0 +1,11 @@
+A Minimal Calendar Widget that's always on current date's month.
+
+<b>Features:</b>
+
+* Contains no ads or payments
+* Always on current date’s month
+* 3x2 (resizable)
+* Displays all events from your calendars with a symbol set (high number becomes generic)
+* Native widget configuration access or press widget’s top right corner
+* Pressing on any other part of the widget opens calendar application
+* Configurable: start day of the week, calendar (gregorian or holocene), show declined events, focus on current week, open calendar on clicked day, theme, symbol set, symbol set colour, transparency, text size

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,6 +1,0 @@
-Minimal Calendar Widget that's always on current date's month
-· 3x2 (resizable)
-· Displays all events from your calendars with a symbol set (high number becomes generic)
-· Native widget configuration access or press widget's top right corner
-· Pressing on any other part of the widget opens calendar application
-· Configurable: start day of the week, calendar (gregorian or holocene), show declined events, focus on current week, open calendar on clicked day, theme, symbol set, symbol set colour, transparency, text size


### PR DESCRIPTION
This PR improves formatting for the English full description, so it can be rendered as Markdown (much nicer display, supported e.g. at IzzyOnDroid) while still being compatible to the format understood by F-Droid and Playstore.

It also adds German short and full description.